### PR TITLE
Fix inverted keyboard pan directions

### DIFF
--- a/src/core/event/keyboard/transformCanvasHandler.ts
+++ b/src/core/event/keyboard/transformCanvasHandler.ts
@@ -30,16 +30,16 @@ export class TransformCanvasHandler {
 
     switch (direction) {
       case KeyCode.ARROW_LEFT:
-        deltaX = panDistance
-        break
-      case KeyCode.ARROW_RIGHT:
         deltaX = -panDistance
         break
+      case KeyCode.ARROW_RIGHT:
+        deltaX = panDistance
+        break
       case KeyCode.ARROW_UP:
-        deltaY = panDistance
+        deltaY = -panDistance
         break
       case KeyCode.ARROW_DOWN:
-        deltaY = -panDistance
+        deltaY = panDistance
         break
     }
 


### PR DESCRIPTION
The pan logic in `TransformCanvasHandler` was using inverted delta values for the X and Y axes. This caused pressing LEFT to move the viewport right, etc. The deltas have been corrected so that arrow key presses result in intuitive canvas movement.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.